### PR TITLE
Crit update - Adding critical hits

### DIFF
--- a/client/src/components/DonateButton/index.js
+++ b/client/src/components/DonateButton/index.js
@@ -63,7 +63,7 @@ const DonateButton = (props) => {
           disableFunding={['venmo']}
           onSuccess={(details, data) => {
             setSnackbarDisplay(true)
-            setMessage(`Transaction completed by ${details.payer.name.given_name}. Thank you for your support! :)`)
+            setMessage(`Donation made by ${details.payer.name.given_name}. Thank you for your support! :)`)
           }}
 
         />

--- a/client/src/components/DonateButton/index.js
+++ b/client/src/components/DonateButton/index.js
@@ -11,7 +11,7 @@ const DonateButton = (props) => {
   const [snackbarDisplay, setSnackbarDisplay] = useState(false);
   const [message, setMessage] = useState('');
   const pattern = new RegExp(/^[0-9]*$/g)
-  
+
   useEffect(() => {
     if (pattern.test(amount)) {
       setAmountError(false);
@@ -23,12 +23,12 @@ const DonateButton = (props) => {
     }
   }, [amount]);
   return (
-    <div style={{display: "flex", flex: 1, flexDirection: "column"}}>
+    <div style={{ display: "flex", flex: 1, flexDirection: "column" }}>
       <TextField
         id="amountInput"
         label="Donation amount"
         variant="outlined"
-        error={amountError} 
+        error={amountError}
         helperText={amountHelperText}
         InputProps={{
           startAdornment: <InputAdornment position="start">$</InputAdornment>,
@@ -46,7 +46,7 @@ const DonateButton = (props) => {
           disableFunding={['venmo']}
           onSuccess={(details, data) => {
             setSnackbarDisplay(true)
-            setMessage(`Transaction completed by ${details.payer.name.given_name}. Thank you for your support! :)`)
+            setMessage(`Donation made by ${details.payer.name.given_name}. Thank you for your support! :)`)
           }}
           options={{
             clientId: process.env.REACT_APP_CLIENT_ID

--- a/client/src/components/InventoryPopup/index.js
+++ b/client/src/components/InventoryPopup/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import Snackbar from "@material-ui/core/Snackbar";
 import MuiAlert from "@material-ui/lab/Alert";
 import { makeStyles } from "@material-ui/core/styles";
+import { camelToTitle } from '../../utils/functions';
 
 function Alert(props) {
     return <MuiAlert elevation={6} variant="filled" {...props} />;
@@ -52,38 +53,43 @@ const InventoryPopup = (props) => {
         if (items !== []) {
             let note;
             items.forEach((item) => {
-                console.log("EGG", Object.values(item)[0])
+                const itemName = Object.keys(item);
+                const quantity = Object.values(item)[0];
+                const armorPiece = Object.values(item);
                 if (item.none || item.fight || item.luckCheck || item.torchCheck || item.end || item.death) {
                     // if no modifier is present, just return.
                     setDisplay(false);
                     return;
                 } else if (item.length && item.head || item.chest || item.hands || item.legs || item.feet) {
-                    note = `You equipped the ${Object.values(item)}. `
+                    note = `You equipped the ${armorPiece}. `
                     addIfUnique(note);
                 } else if (item.torch === 0) {
-                    note = `You lost your torch. `;
+                    note = `You lost your torch.`;
                     addIfUnique(note);
                 } else if (Math.sign(item.health) === 1) {
                     note = `You restored ${item.health} health.`
                     addIfUnique(note);
-                } else if (Object.values(item)[0] >= 1) {
+                } else if (quantity >= 1) {
                     // if the modifier returns as positive, user gains an item
-                    note = `You gained ${Object.values(item)} ${Object.keys(item)}. `;
+                    note = `You gained ${quantity} ${camelToTitle(itemName[0])}. `;
+                    if(itemName[0] === 'healthPotion' && quantity > 1) {
+                        note = `You gained ${quantity} Health Potions. `;
+                    }
                     addIfUnique(note);
                 } else if (item.weapon && Object.values(item.weapon)[1] > 1) {
                     // if the weapon has more than 1 damage (not no weapon)
                     note = `You gained the ${item.weapon.name}, which does ${item.weapon.dmg} damage. `;
                     addIfUnique(note);
-                } else if (Math.sign(Object.values(item)) === -1) {
+                } else if (Math.sign(quantity) === -1) {
                     // if the modifier is negative, set the note to say you lost an item
-                    note = `You lost ${Object.values(item)} ${Object.keys(item)}. `;
+                    note = `You lost ${quantity} ${itemName}. `;
                     addIfUnique(note);
                 } else if (Object.values(item.weapon)[1] <= 1) {
                     note = `You lost your weapon. Your damage has been reduced to 1. `;
                     addIfUnique(note);
                 } else {
                     // if the item is neither negative nor positive (0), just say that they lost the item. This relates to things like the torch
-                    note = `You lost your ${Object.values(item)}. `;
+                    note = `You lost your ${armorPiece}. `;
                     addIfUnique(note);
                 }
             });

--- a/client/src/components/InventoryPopup/index.js
+++ b/client/src/components/InventoryPopup/index.js
@@ -55,42 +55,42 @@ const InventoryPopup = (props) => {
             items.forEach((item) => {
                 const itemName = Object.keys(item);
                 const quantity = Object.values(item)[0];
-                const armorPiece = Object.values(item);
+                const armorPiece = Object.values(item)[0];
                 if (item.none || item.fight || item.luckCheck || item.torchCheck || item.end || item.death) {
                     // if no modifier is present, just return.
                     setDisplay(false);
                     return;
                 } else if (item.length && item.head || item.chest || item.hands || item.legs || item.feet) {
                     note = `You equipped the ${armorPiece}. `
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else if (item.torch === 0) {
                     note = `You lost your torch.`;
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else if (Math.sign(item.health) === 1) {
                     note = `You restored ${item.health} health.`
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else if (quantity >= 1) {
                     // if the modifier returns as positive, user gains an item
                     note = `You gained ${quantity} ${camelToTitle(itemName[0])}. `;
                     if(itemName[0] === 'healthPotion' && quantity > 1) {
                         note = `You gained ${quantity} Health Potions. `;
                     }
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else if (item.weapon && Object.values(item.weapon)[1] > 1) {
                     // if the weapon has more than 1 damage (not no weapon)
                     note = `You gained the ${item.weapon.name}, which does ${item.weapon.dmg} damage. `;
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else if (Math.sign(quantity) === -1) {
                     // if the modifier is negative, set the note to say you lost an item
                     note = `You lost ${quantity} ${itemName}. `;
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else if (Object.values(item.weapon)[1] <= 1) {
                     note = `You lost your weapon. Your damage has been reduced to 1. `;
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 } else {
                     // if the item is neither negative nor positive (0), just say that they lost the item. This relates to things like the torch
                     note = `You lost your ${armorPiece}. `;
-                    addIfUnique(note);
+                    return addIfUnique(note);
                 }
             });
         }

--- a/client/src/pages/CreateCharacter/index.js
+++ b/client/src/pages/CreateCharacter/index.js
@@ -69,7 +69,7 @@ const CreateCharacter = () => {
                 setWisdom(2);
                 setLuck(4);
                 setDescription("As deadly as they are cunning, the rogue utilizes their luck to end fights quickly.")
-                setSkill("Lucky Strike: Guaranteed critical hit next turn.")
+                setSkill("Gambler's Strike: Massive increase to critical hit chance on the next turn.")
                 setDescriptionDisplay(1)
                 break;
             case "Paladin":

--- a/client/src/pages/CreateCharacter/index.js
+++ b/client/src/pages/CreateCharacter/index.js
@@ -69,7 +69,7 @@ const CreateCharacter = () => {
                 setWisdom(2);
                 setLuck(4);
                 setDescription("As deadly as they are cunning, the rogue utilizes their luck to end fights quickly.")
-                setSkill("Rapid Attack: Doubles special attack damage")
+                setSkill("Lucky Strike: Guaranteed critical hit next turn.")
                 setDescriptionDisplay(1)
                 break;
             case "Paladin":

--- a/client/src/pages/MainStory/index.js
+++ b/client/src/pages/MainStory/index.js
@@ -67,6 +67,8 @@ const MainStory = () => {
     const [cooldownRound, setCooldownRound] = useState(0);
     const [warriorDefenseRound, setWarriorDefenseRound] = useState(0);
     const [tempDefense, setTempDefense] = useState(0);
+    const [rogueLuckRound, setRogueLuckRound] = useState(0)
+    const [tempLuck, setTempLuck] = useState(0);
 
     useEffect(() => {
         // grabs the current character selected and stores it in state
@@ -410,7 +412,9 @@ const MainStory = () => {
                         setDefense(defense + results.skillResult);
                         setWarriorDefenseRound(roundCount + 3)
                     } else if (currentCharacter.charClass === "Rogue") {
-                        setCurrentEnemyHealth(currentEnemyHealth - results.skillResult)
+                        setTempLuck(luck);
+                        setLuck(20);
+                        setRogueLuckRound(roundCount + 1)
                     } else {
                         setCurrentUserHealth(maxHealth)
                     }
@@ -427,6 +431,10 @@ const MainStory = () => {
         if (currentCharacter.charClass === "Warrior" && roundCount === warriorDefenseRound) {
             // returns the warrior's defense to it's regular level
             setDefense(tempDefense);
+        }
+        if (currentCharacter.charClass === "Rogue" && roundCount === rogueLuckRound) {
+            // returns the warrior's defense to it's regular level
+            setLuck(tempLuck);
         }
         // If a skill has been used and both the cooldown and roundCount are the same, make the button back to how it was.
         if(cooldownRound === roundCount && skillUsed) {

--- a/client/src/pages/MainStory/index.js
+++ b/client/src/pages/MainStory/index.js
@@ -413,7 +413,7 @@ const MainStory = () => {
                         setWarriorDefenseRound(roundCount + 3)
                     } else if (currentCharacter.charClass === "Rogue") {
                         setTempLuck(luck);
-                        setLuck(20);
+                        setLuck(results.skillResult);
                         setRogueLuckRound(roundCount + 1)
                     } else {
                         setCurrentUserHealth(maxHealth)
@@ -433,7 +433,7 @@ const MainStory = () => {
             setDefense(tempDefense);
         }
         if (currentCharacter.charClass === "Rogue" && roundCount === rogueLuckRound) {
-            // returns the warrior's defense to it's regular level
+            // returns the rogue's luck to it's regular level
             setLuck(tempLuck);
         }
         // If a skill has been used and both the cooldown and roundCount are the same, make the button back to how it was.

--- a/client/src/pages/MainStory/index.js
+++ b/client/src/pages/MainStory/index.js
@@ -299,7 +299,7 @@ const MainStory = () => {
 
     const enemyTurn = () => {
         const enemyAttack = async () => {
-            return attacks.enemyNormalAttack(currentEnemy.weapon.dmg, currentEnemy.strength, defense);
+            return attacks.enemyNormalAttack(currentEnemy.weapon.dmg, currentEnemy.strength, defense, currentEnemy.luck);
         };
 
         enemyAttack().then((results) => {
@@ -362,7 +362,7 @@ const MainStory = () => {
         switch (option.label) {
             case "Normal Attack":
                 const normalAttack = async () => {
-                    return attacks.normalAttack(weaponDmg, strength, currentEnemy.defense);
+                    return attacks.normalAttack(weaponDmg, strength, currentEnemy.defense, luck);
                 };
                 normalAttack().then(results => {
                     setCurrentEnemyHealth(currentEnemyHealth - results.finalDamage)

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -1,6 +1,13 @@
 const diceRoll = () => {
     return(Math.floor(Math.random() * 6) + 1);
-}
+};
+
+const critChance = (luck) => {
+    const initialRoll = (Math.floor(Math.random() * 20) + 1)
+    const luckCheck = (initialRoll + luck)
+    // If the roll + luck is 19 or higher, it's a crit.
+    return luckCheck >= 19;
+};
 
 let battleText;
 
@@ -9,12 +16,14 @@ export default {
 
     // USER ATTACKS
     // Normal attack does weapon damage * dice roll, + strength * 2, divided by enemy defense
-    normalAttack: (weaponDamage, strength, enemyDef) => {
+    normalAttack: (weaponDamage, strength, enemyDef, luck) => {
         const initialRoll = diceRoll();
         const finalDamage = Math.ceil(((weaponDamage * initialRoll) + (strength * 2)) / enemyDef);
-
-        let battleText = `You rolled a ${initialRoll}! \n Your normal attack does ${finalDamage} damage.`
-
+        if (critChance(luck)) {
+            battleText = `You rolled a ${initialRoll}, and it was a crit! \n Your normal attack does ${finalDamage * 2} damage.`
+        } else {
+            battleText = `You rolled a ${initialRoll}! \n Your normal attack does ${finalDamage} damage.`
+        }
         return {
             battleText,
             finalDamage
@@ -25,7 +34,6 @@ export default {
     specialAttack: (weaponDamage, strength, enemyDef, luck, enemyLuck) => {
         const initalRoll = diceRoll();    
         let finalDamage = Math.ceil((((3 * weaponDamage) * initalRoll) + (strength * 3)) / enemyDef);
-    
         
         console.log(`Dice roll: ${initalRoll}`);
         console.log(`Weapon Damage: ${weaponDamage}`);
@@ -39,6 +47,13 @@ export default {
         let enemyLuckRoll = diceRoll();
 
         if (myLuckRoll + luck >= enemyLuckRoll + enemyLuck) {
+            if (critChance(luck / 2)) {
+                battleText = `You roll for a special attack. \n You compare luck values with the enemy, your roll is higher, AND it's a crit! \n Your special attack does ${finalDamage * 2} damage!`;
+                return {
+                    battleText,
+                    finalDamage
+                };
+            }
             battleText = `You roll for a special attack. \n You compare luck values with the enemy and your roll is higher! \n Your special attack does ${finalDamage} damage!`;
             return {
                 battleText,

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -53,7 +53,7 @@ export default {
         let enemyLuckRoll = diceRoll();
 
         if (myLuckRoll + luck >= enemyLuckRoll + enemyLuck) {
-            if (critChance(Math.floor(luck / 2))) {
+            if (critChance(Math.floor(luck / 1.5))) {
                 battleText = `You roll for a special attack. \n You compare luck values with the enemy, your roll is higher, AND it's a crit! \n Your special attack does ${critDamage} damage!`;
                 return {
                     battleText,
@@ -136,9 +136,9 @@ export default {
                 skillResult = 20;
                 break;
             case "Rogue":
-                skill = "Lucky Strike";
-                battleText = `You used Lucky Strike. Your luck has been temporarily increased!`
-                skillResult = 40;
+                skill = "Gambler's Strike";
+                battleText = `You used Gambler's Strike. Your luck has been massively increased for 1 turn!`
+                skillResult = 20;
                 break;
             case "Paladin":
                 skill = "Holy remedy";

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -19,8 +19,9 @@ export default {
     normalAttack: (weaponDamage, strength, enemyDef, luck) => {
         const initialRoll = diceRoll();
         const finalDamage = Math.ceil(((weaponDamage * initialRoll) + (strength * 2)) / enemyDef);
+        const critDamage = ((weaponDamage * initialRoll) + (strength * 2));
         if (critChance(luck)) {
-            battleText = `You rolled a ${initialRoll}, and it was a crit! \n Your normal attack does ${finalDamage * 2} damage.`
+            battleText = `You rolled a ${initialRoll}, and it was a crit! \n Your normal attack does ${critDamage} damage.`
         } else {
             battleText = `You rolled a ${initialRoll}! \n Your normal attack does ${finalDamage} damage.`
         }
@@ -34,7 +35,8 @@ export default {
     specialAttack: (weaponDamage, strength, enemyDef, luck, enemyLuck) => {
         const initalRoll = diceRoll();    
         let finalDamage = Math.ceil((((3 * weaponDamage) * initalRoll) + (strength * 3)) / enemyDef);
-        
+        let critDamage = (((3 * weaponDamage) * initalRoll) + (strength * 3));
+
         console.log(`Dice roll: ${initalRoll}`);
         console.log(`Weapon Damage: ${weaponDamage}`);
         console.log(`Str: ${strength}`);
@@ -48,10 +50,10 @@ export default {
 
         if (myLuckRoll + luck >= enemyLuckRoll + enemyLuck) {
             if (critChance(luck / 2)) {
-                battleText = `You roll for a special attack. \n You compare luck values with the enemy, your roll is higher, AND it's a crit! \n Your special attack does ${finalDamage * 2} damage!`;
+                battleText = `You roll for a special attack. \n You compare luck values with the enemy, your roll is higher, AND it's a crit! \n Your special attack does ${critDamage} damage!`;
                 return {
                     battleText,
-                    finalDamage
+                    critDamage
                 };
             }
             battleText = `You roll for a special attack. \n You compare luck values with the enemy and your roll is higher! \n Your special attack does ${finalDamage} damage!`;

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -137,8 +137,8 @@ export default {
                 break;
             case "Rogue":
                 skill = "Lucky Strike";
-                skillResult = Math.ceil(((3 * 9) * initalRoll) / enemyDef);
-                battleText = `You used Rapid Attack. Fast as lightning, you strike the enemy for ${skillResult} damage!`
+                battleText = `You used Lucky Strike. Your luck has been temporarily increased!`
+                skillResult = 40;
                 break;
             case "Paladin":
                 skill = "Holy remedy";

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -1,5 +1,5 @@
 const diceRoll = () => {
-    return(Math.floor(Math.random() * 6) + 1);
+    return (Math.floor(Math.random() * 6) + 1);
 };
 
 const critChance = (luck) => {
@@ -33,7 +33,7 @@ export default {
 
     // Normal attack does 3 * weapon damage, * dice roll, + strength * 3, divided by enemy defense
     specialAttack: (weaponDamage, strength, enemyDef, luck, enemyLuck) => {
-        const initalRoll = diceRoll();    
+        const initalRoll = diceRoll();
         let finalDamage = Math.ceil((((3 * weaponDamage) * initalRoll) + (strength * 3)) / enemyDef);
         let critDamage = (((3 * weaponDamage) * initalRoll) + (strength * 3));
 
@@ -62,7 +62,7 @@ export default {
                 finalDamage
             };
         } else {
-            battleText =  `You roll for a special attack. \n You compare luck values with the enemy and your roll is lower. \n Your attack misses!`;
+            battleText = `You roll for a special attack. \n You compare luck values with the enemy and your roll is lower. \n Your attack misses!`;
             finalDamage = 0;
             return {
                 battleText,
@@ -92,7 +92,7 @@ export default {
                 healthIncrease
             }
         }
-        
+
     },
 
     useSkill: (charClass, wisdom, enemyDef) => {
@@ -126,7 +126,7 @@ export default {
             cooldownLength = 0;
         }
 
-        switch(charClass) {
+        switch (charClass) {
             case "Warrior":
                 skill = "Stalwart defense";
                 battleText = "You used Stalwart Defense. Your defense has been temporarily increased!"
@@ -134,7 +134,7 @@ export default {
                 break;
             case "Rogue":
                 skill = "Rapid attack";
-                const initalRoll = diceRoll();    
+                const initalRoll = diceRoll();
                 skillResult = Math.ceil(((3 * 9) * initalRoll) / enemyDef);
                 battleText = `You used Rapid Attack. Fast as lightning, you strike the enemy for ${skillResult} damage!`
                 break;
@@ -153,13 +153,22 @@ export default {
     },
 
     // ENEMY ATTACKS
-    enemyNormalAttack: (enemyWeapon, strength, myDef) => {
+    enemyNormalAttack: (enemyWeapon, strength, myDef, enemyLuck) => {
         const initialRoll = diceRoll();
         const finalDamage = Math.ceil(((enemyWeapon * initialRoll) + (strength * 2)) / myDef);
+        const critDamage = ((enemyWeapon * initialRoll) + (strength * 2));
+
         console.log(`Enemy weapon ${enemyWeapon}`)
         console.log(`My defense ${myDef}`)
         console.log(`Total damage before divison ${finalDamage * myDef}`)
 
+        if (critChance(enemyLuck)) {
+            battleText = `The enemy rolled a ${initialRoll}! \n Their attack does ${critDamage} damage.`
+            return {
+                battleText,
+                critDamage
+            }
+        }
         battleText = `The enemy rolled a ${initialRoll}! \n Their attack does ${finalDamage} damage.`
         return {
             battleText,
@@ -188,7 +197,7 @@ export default {
         // Story 1 is Dark path traps
         console.log(story)
         if (story === 1) {
-            if(updatedNumber <= 1) {
+            if (updatedNumber <= 1) {
                 options = deathLevel
             } else if (myRoll > 1 && myRoll < 6) {
                 options = badLuckLevel;
@@ -234,7 +243,7 @@ export default {
                 target: options
             }
         ]
-    
+
     },
 
     torchCheck: (torch) => {
@@ -247,9 +256,9 @@ export default {
         }
         console.log(options)
         return {
-                label: "Continue",
-                target: options
-            }
+            label: "Continue",
+            target: options
+        }
     }
 
 }

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -108,8 +108,7 @@ export default {
         // PSUEDOCODE
         // For warrior, set character defense to 20 for 3 turns. After 3 turns, it returns to normal
         // Maybe we need a turn counter? Almost definitely.
-        // For rogue, do the same as special attack but increase weapon damage by a lot (max?) and remove
-        // the luck constraints.
+        // For rogue, guarantee the next attack will crit. (increase luck to 20 for 1 turn)
         // For paladin, heal health completely.
 
         // Once skill has completed, based on Wisdom number - disable the button for that many turns
@@ -137,8 +136,7 @@ export default {
                 skillResult = 20;
                 break;
             case "Rogue":
-                skill = "Rapid attack";
-                const initalRoll = diceRoll();
+                skill = "Lucky Strike";
                 skillResult = Math.ceil(((3 * 9) * initalRoll) / enemyDef);
                 battleText = `You used Rapid Attack. Fast as lightning, you strike the enemy for ${skillResult} damage!`
                 break;

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -19,23 +19,27 @@ export default {
     normalAttack: (weaponDamage, strength, enemyDef, luck) => {
         const initialRoll = diceRoll();
         const finalDamage = Math.ceil(((weaponDamage * initialRoll) + (strength * 2)) / enemyDef);
-        const critDamage = ((weaponDamage * initialRoll) + (strength * 2));
+        const critDamage = (weaponDamage * initialRoll) + (strength * 2);
         if (critChance(luck)) {
             battleText = `You rolled a ${initialRoll}, and it was a crit! \n Your normal attack does ${critDamage} damage.`
+            return {
+                battleText,
+                finalDamage: critDamage
+            };
         } else {
             battleText = `You rolled a ${initialRoll}! \n Your normal attack does ${finalDamage} damage.`
+            return {
+                battleText,
+                finalDamage
+            };
         }
-        return {
-            battleText,
-            finalDamage
-        };
     },
 
     // Normal attack does 3 * weapon damage, * dice roll, + strength * 3, divided by enemy defense
     specialAttack: (weaponDamage, strength, enemyDef, luck, enemyLuck) => {
         const initalRoll = diceRoll();
         let finalDamage = Math.ceil((((3 * weaponDamage) * initalRoll) + (strength * 3)) / enemyDef);
-        let critDamage = (((3 * weaponDamage) * initalRoll) + (strength * 3));
+        let critDamage = ((3 * weaponDamage) * initalRoll) + (strength * 3);
 
         console.log(`Dice roll: ${initalRoll}`);
         console.log(`Weapon Damage: ${weaponDamage}`);
@@ -49,11 +53,11 @@ export default {
         let enemyLuckRoll = diceRoll();
 
         if (myLuckRoll + luck >= enemyLuckRoll + enemyLuck) {
-            if (critChance(luck / 2)) {
+            if (critChance(Math.floor(luck / 2))) {
                 battleText = `You roll for a special attack. \n You compare luck values with the enemy, your roll is higher, AND it's a crit! \n Your special attack does ${critDamage} damage!`;
                 return {
                     battleText,
-                    critDamage
+                    finalDamage: critDamage
                 };
             }
             battleText = `You roll for a special attack. \n You compare luck values with the enemy and your roll is higher! \n Your special attack does ${finalDamage} damage!`;
@@ -156,17 +160,18 @@ export default {
     enemyNormalAttack: (enemyWeapon, strength, myDef, enemyLuck) => {
         const initialRoll = diceRoll();
         const finalDamage = Math.ceil(((enemyWeapon * initialRoll) + (strength * 2)) / myDef);
-        const critDamage = ((enemyWeapon * initialRoll) + (strength * 2));
+        const critDamage = (enemyWeapon * initialRoll) + (strength * 2);
 
         console.log(`Enemy weapon ${enemyWeapon}`)
         console.log(`My defense ${myDef}`)
         console.log(`Total damage before divison ${finalDamage * myDef}`)
-
+        console.log(finalDamage);
+        console.log(critDamage);
         if (critChance(enemyLuck)) {
             battleText = `The enemy rolled a ${initialRoll}! \n Their attack does ${critDamage} damage.`
             return {
                 battleText,
-                critDamage
+                finalDamage: critDamage
             }
         }
         battleText = `The enemy rolled a ${initialRoll}! \n Their attack does ${finalDamage} damage.`

--- a/client/src/utils/attacks.js
+++ b/client/src/utils/attacks.js
@@ -168,7 +168,7 @@ export default {
         console.log(finalDamage);
         console.log(critDamage);
         if (critChance(enemyLuck)) {
-            battleText = `The enemy rolled a ${initialRoll}! \n Their attack does ${critDamage} damage.`
+            battleText = `The enemy rolled a ${initialRoll} and it was a crit! \n Their attack does ${critDamage} damage.`
             return {
                 battleText,
                 finalDamage: critDamage

--- a/client/src/utils/functions.js
+++ b/client/src/utils/functions.js
@@ -1,0 +1,4 @@
+export const camelToTitle = value => {
+const result = value.replace(/([A-Z])/g, " $1");
+return result.charAt(0).toUpperCase() + result.slice(1);
+};


### PR DESCRIPTION
Realized that for a better experience, it might be cool to add the option for both the player and enemies to have the chance for a critical hit. A critical hit bypasses the defense, but it's fairly hard to get. It's only a 10% chance (dice roll d20 + player luck >= 19) so i think it makes it quite fair. It's even harder to get a crit on a special attack, with your luck divided by 1.5 .

This update also includes a change to the Rogue's skill, which was initially very OP. It now grants a temporary increase to the Rogue's luck (similiar to how the warrior works) of 20. This means that it essentially guarantees a crit on a normal strike, there's still a chance for a special attack to _not_ crit as the luck passed in is only 13, rather than 20 (based on it being divided by 1.5). I've also renamed it `Gambler's Strike`.

Made some changes to the modifier checks on the InventoryPopup page so it's easier to read.