### PR TITLE
Styling fix

### DIFF
--- a/src/components/CharacterBlock/index.js
+++ b/src/components/CharacterBlock/index.js
@@ -140,7 +140,12 @@ const BoundCharacterBlock = (props) => {
 				</section>
 			</div>
 			<section className="charButtons">
-				<Button variant="contained" color="primary" id="play" onClick={() => playThisCharacter(character)}>
+				<Button
+					className="primaryButton"
+					variant="contained"
+					id="play"
+					onClick={() => playThisCharacter(character)}
+				>
                     PLAY
 				</Button>
 

--- a/src/components/ChoiceBlock/index.js
+++ b/src/components/ChoiceBlock/index.js
@@ -130,7 +130,11 @@ const BoundChoiceBlock = (props) => {
 		return options.map(option => {
 			return (
 				<div className={`options ${optionFade}`} key={option.label}>
-					<Button className="optionText primaryButton" variant="contained" id={stringToCamel(option.label)} onClick={() => handleClick(option)}>
+					<Button
+						className="optionText primaryButton"
+						variant="contained"
+						id={stringToCamel(option.label)}
+						onClick={() => handleClick(option)}>
 						{option.label}
 					</Button>
 				</div>

--- a/src/components/ChoiceBlock/index.js
+++ b/src/components/ChoiceBlock/index.js
@@ -111,7 +111,13 @@ const BoundChoiceBlock = (props) => {
 			{options.map(fightOption => {
 				return (
 					<div className={`options ${optionFade}`} key={fightOption.label}>
-						<Button className="optionText" variant="contained" color="secondary" id={stringToCamel(fightOption.label)} onClick={() => handleFight(fightOption)} disabled={buttonDisabled}>
+						<Button
+							className="optionText choiceButton"
+							variant="contained"
+							color="secondary"
+							id={stringToCamel(fightOption.label)}
+							onClick={() => handleFight(fightOption)}
+							disabled={buttonDisabled}>
 							{fightOption.label}
 						</Button>
 					</div>
@@ -124,7 +130,7 @@ const BoundChoiceBlock = (props) => {
 		return options.map(option => {
 			return (
 				<div className={`options ${optionFade}`} key={option.label}>
-					<Button className="optionText" variant="contained" color="primary" id={stringToCamel(option.label)} onClick={() => handleClick(option)}>
+					<Button className="optionText primaryButton" variant="contained" id={stringToCamel(option.label)} onClick={() => handleClick(option)}>
 						{option.label}
 					</Button>
 				</div>

--- a/src/components/Credits/index.js
+++ b/src/components/Credits/index.js
@@ -44,28 +44,19 @@ const Credits = () => {
 				BackdropProps={{
 					timeout: 500,
 				}}
-				style={{ margin: '6% auto'}}
+				style={{ margin: '2% auto'}}
 			>
 				<Fade in={open}>
-					<div style={{overflowY: 'scroll', maxHeight: '80vh', padding: '40px'}}>
+					<div id="creditsModal" style={{overflowY: 'scroll', maxHeight: '80vh', padding: '40px'}}>
 						<h1 id="transition-modal-title" className="title" style={{margin: '0 30px'}}>CREDITS</h1>  
 						<section className="section" id="created">
 							<h2>Created by</h2>
 							<span>Sean Belverstone</span>
 						</section>
-						<section className="section" id="built">
-							<h2>Built with: </h2>
-							<div className="imageSection">
-								<img className='images' href="https://reactjs.org/" target="_blank" src={react} />
-								<img className='images' href="https://reactjs.org/" target="_blank" src={materialUi} />
-								<img className='images' href="https://reactjs.org/" target="_blank" src={express} />
-								<img className='images' href="https://reactjs.org/" target="_blank" src={node} />
-								<img className='images' href="https://reactjs.org/" target="_blank" src={mysql} />
-							</div>
-						</section>
 						<section className="section" id="logoCredit">
-							<h2>Logo Design</h2>
+							<h2>Images</h2>
 							<span>Logo design created on Canva.</span>
+							<span>Beastmaster model created by <i>ulumbachrul</i>. You can find more of his work <a href="https://www.fiverr.com/ulumbachrul" target="none">here</a>.</span>
 							<span>All other images were used from free websites across the internet.</span>
 						</section>
 						<section className="section" id="testers">
@@ -80,6 +71,16 @@ const Credits = () => {
 							<h2>With special thanks to</h2>
 							<span>Olivia Yeargain, for putting up with my long nights and constant styling advice.</span>
 							<span>Full Stack Coding Bootcamp @ UT Austin, for teaching me the skills I needed to get started.</span>
+						</section>
+						<section className="section" id="built">
+							<h2>Built with: </h2>
+							<div className="imageSection">
+								<img className='images' href="https://reactjs.org/" target="_blank" src={react} />
+								<img className='images' href="https://reactjs.org/" target="_blank" src={materialUi} />
+								<img className='images' href="https://reactjs.org/" target="_blank" src={express} />
+								<img className='images' href="https://reactjs.org/" target="_blank" src={node} />
+								<img className='images' href="https://reactjs.org/" target="_blank" src={mysql} />
+							</div>
 						</section>
 						<section className="section" style={{marginTop: '40px'}}>
 							<span>If you would like to buy me a coffee or donate to help me continue to develop this one man-show, it would mean so much to me! :)</span>

--- a/src/components/Credits/index.js
+++ b/src/components/Credits/index.js
@@ -44,6 +44,7 @@ const Credits = () => {
 				BackdropProps={{
 					timeout: 500,
 				}}
+				style={{ margin: '6% auto'}}
 			>
 				<Fade in={open}>
 					<div style={{overflowY: 'scroll', maxHeight: '80vh', padding: '40px'}}>

--- a/src/components/Credits/index.js
+++ b/src/components/Credits/index.js
@@ -25,7 +25,13 @@ const Credits = () => {
 
 	return (
 		<div>
-			<Button type="button" variant="contained" id="inventory" onClick={handleOpen}>
+			<Button
+				className="primaryButton"
+				type="button"
+				variant="contained"
+				id="inventory"
+				onClick={handleOpen}
+			>
         Credits
 			</Button>
 			<Modal

--- a/src/components/DefaultPopup/index.js
+++ b/src/components/DefaultPopup/index.js
@@ -17,6 +17,10 @@ const DefaultPopup = (props) => {
 		customClass
 	} = props;
 
+	display && setTimeout(() => {
+		handleClose();
+	}, 6000);
+
 	const handleClose = () => {
 		if (destination !== '' && snackbarColor !== 'error') {
 			history(destination);

--- a/src/components/DefaultPopup/index.js
+++ b/src/components/DefaultPopup/index.js
@@ -1,13 +1,10 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
-import Snackbar from '@mui/material/Snackbar';
-import MuiAlert from '@mui/material/Alert';
+import Alert from '@mui/material/Alert';
 import { useNavigate } from 'react-router-dom';
-
-function Alert(props) {
-
-	return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
 
 const DefaultPopup = (props) => {
 	let history = useNavigate();
@@ -26,21 +23,29 @@ const DefaultPopup = (props) => {
 		}
 		setDisplay(false);
 	};
-
 	return (
-		<div>
-			<Snackbar
+		<Collapse in={display}>
+			<Alert
 				className={customClass}
-				open={display}
-				autoHideDuration={6000}
-				onClose={handleClose}
-				anchorOrigin={{vertical: 'top', horizontal: 'right'}}
-				style={{height: '20%', top: '40vh', width: '23vw'}}>
-				<Alert  onClose={handleClose} severity={snackbarColor}>
-					{message}
-				</Alert>
-			</Snackbar>
-		</div>
+				severity={snackbarColor}
+				variant="filled"
+				action={
+					<IconButton
+						aria-label="close"
+						color="inherit"
+						size="small"
+						onClick={() => {
+							handleClose(false);
+						}}
+					>
+						<CloseIcon fontSize="inherit" />
+					</IconButton>
+				}
+				sx={{ mb: 2 }}
+			>
+				{message}
+			</Alert>
+		</Collapse>
 	);
 };
 

--- a/src/components/DefaultPopup/index.js
+++ b/src/components/DefaultPopup/index.js
@@ -17,10 +17,6 @@ const DefaultPopup = (props) => {
 		customClass
 	} = props;
 
-	display && setTimeout(() => {
-		handleClose();
-	}, 6000);
-
 	const handleClose = () => {
 		if (destination !== '' && snackbarColor !== 'error') {
 			history(destination);

--- a/src/components/DeleteButton/index.js
+++ b/src/components/DeleteButton/index.js
@@ -75,7 +75,7 @@ export default function DeleteButton(props) {
 
 	return (
 		<div id={props.id}>
-			<Button variant="contained" color="secondary" id="delete" onClick={handleClickOpen}>
+			<Button variant="contained" className="secondaryButton" id="delete" onClick={handleClickOpen}>
 				{text ? text : 'DELETE'}
 			</Button>
 			<SimpleDialog selectedValue={selectedValue} open={open} onClose={handleClose} customText={customText} />

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -29,7 +29,7 @@ const Info = (props) => {
 		<div className={optionFade}>
 			<InfoIcon className="infoIcon" onMouseEnter={onHover} onMouseLeave={onLeave} onClick={onHover} />
 			{hover ? (
-				<div id="dialog" style={{ backgroundColor: 'var(--foreground)' }} onMouseEnter={onHover} onMouseLeave={onLeave}>
+				<div id="dialog" onMouseEnter={onHover} onMouseLeave={onLeave}>
 					<h2 style={{ textAlign: 'center' }}>{infoProps.title}</h2>
 					{infoProps.main.map(prop => (
 						<React.Fragment key={prop.header.toLowerCase()}>

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -29,7 +29,7 @@ const Info = (props) => {
 		<div className={optionFade}>
 			<InfoIcon className="infoIcon" onMouseEnter={onHover} onMouseLeave={onLeave} onClick={onHover} />
 			{hover ? (
-				<div id="dialog" onMouseEnter={onHover} onMouseLeave={onLeave}>
+				<div id="dialog" style={{ backgroundColor: 'var(--foreground)' }} onMouseEnter={onHover} onMouseLeave={onLeave}>
 					<h2 style={{ textAlign: 'center' }}>{infoProps.title}</h2>
 					{infoProps.main.map(prop => (
 						<React.Fragment key={prop.header.toLowerCase()}>

--- a/src/components/Inventory/index.js
+++ b/src/components/Inventory/index.js
@@ -68,7 +68,13 @@ const BoundInventory = (props) => {
 
 	return (
 		<div>
-			<Button type="button" variant="contained" id="inventory" onClick={handleOpen}>
+			<Button
+				className="primaryButton"
+				type="button"
+				variant="contained"
+				id="inventory"
+				onClick={handleOpen}
+			>
                 Inventory
 			</Button>
 			<Modal
@@ -81,7 +87,7 @@ const BoundInventory = (props) => {
 				BackdropProps={{
 					timeout: 500,
 				}}
-				style={{ margin: '6% auto'}}
+				style={{ margin: '2% auto' }}
 			>
 				<Fade in={open}>
 					<div id="inventoryModal">

--- a/src/components/Inventory/index.js
+++ b/src/components/Inventory/index.js
@@ -81,6 +81,7 @@ const BoundInventory = (props) => {
 				BackdropProps={{
 					timeout: 500,
 				}}
+				style={{ margin: '6% auto'}}
 			>
 				<Fade in={open}>
 					<div id="inventoryModal">

--- a/src/components/Inventory/style.css
+++ b/src/components/Inventory/style.css
@@ -39,7 +39,6 @@
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
-  margin: 2px;
 }
 
 #topMisc,
@@ -64,6 +63,7 @@
   right: 69% !important;
   height: min-content;
   overflow-y: scroll;
+  border: 2px black solid;
 }
 
 /* Misc items */
@@ -119,7 +119,8 @@
 @media screen and (max-width: 1382px) {
   #statsBlock #dialog {
     top: 24% !important;
-    right: 11% !important;
+	width: 25vw;
+	height: 50vh;
   }
 }
 
@@ -129,7 +130,6 @@
   }
   #statsBlock #dialog {
     top: 24% !important;
-    right: 11% !important;
   }
 }
 
@@ -140,6 +140,7 @@
   #statsBlock #dialog {
     top: 27% !important;
     right: 14% !important;
+	width: 35vw;
     height: 45vh;
   }
 }
@@ -151,6 +152,7 @@
   #statsBlock #dialog {
     top: 14% !important;
     right: 19% !important;
+	width: 38vw;
     height: 50vh;
   }
 }

--- a/src/components/InventoryPopup/index.js
+++ b/src/components/InventoryPopup/index.js
@@ -90,8 +90,11 @@ const InventoryPopup = (props) => {
 	};
 
 	return (
-		<div id="inventoryPopup">
-			<Collapse in={display}>
+		<div id="inventoryPopup" style={{
+
+		}}>
+			<Collapse
+				in={display}>
 				<Alert
 					severity="info"
 					variant="filled"

--- a/src/components/InventoryPopup/index.js
+++ b/src/components/InventoryPopup/index.js
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Snackbar from '@mui/material/Snackbar';
-import MuiAlert from '@mui/material/Alert';
+import { Alert } from '@mui/material';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
 import { camelToTitle } from '../../utils/functions';
 
-function Alert(props) {
-	return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
 const InventoryPopup = (props) => {
 	const {
 		display,
@@ -92,11 +91,27 @@ const InventoryPopup = (props) => {
 
 	return (
 		<div id="inventoryPopup">
-			<Snackbar open={display} autoHideDuration={6000} onClose={handleClose} anchorOrigin={{ vertical: 'top', horizontal: 'left' }} style={{ height: '100%' }}>
-				<Alert onClose={handleClose} severity="info">
+			<Collapse in={display}>
+				<Alert
+					severity="info"
+					variant="filled"
+					action={
+						<IconButton
+							aria-label="close"
+							color="inherit"
+							size="small"
+							onClick={() => {
+								handleClose(false);
+							}}
+						>
+							<CloseIcon fontSize="inherit" />
+						</IconButton>
+					}
+					sx={{ mb: 2 }}
+				>
 					{messages}
 				</Alert>
-			</Snackbar>
+			</Collapse>
 		</div>
 	);
 };

--- a/src/components/ProfileModal/index.js
+++ b/src/components/ProfileModal/index.js
@@ -160,13 +160,14 @@ const ProfileModal = (props) => {
 				BackdropProps={{
 					timeout: 500,
 				}}
+				style={{ margin: '6% auto'}}
 			>
 				<Fade in={open}>
 					<div id="profileModal">
 						<h2 className="title" style={{ textDecoration: 'none' }}>EDIT ACCOUNT</h2>
 						<div style={{ display: 'flex', justifyContent: 'space-between' }}>
 							<p>Username: {user.username}</p>
-							<a style={{ color: 'var(--wisdom)' }} onClick={() => displayEditBlock('username')}>
+							<a style={{ color: 'var(--primary)' }} onClick={() => displayEditBlock('username')}>
 								{displayUsername === 'none' ? 'Edit' : 'Hide'}
 							</a>
 						</div>
@@ -180,13 +181,13 @@ const ProfileModal = (props) => {
 								helperText={usernameHelperText}
 								value={username}
 							/>
-							<Button variant="contained" color="primary" onClick={checkUsername}>
+							<Button className="primaryButton" variant="contained" color="primary" onClick={checkUsername}>
 								Submit
 							</Button>
 						</form>
 						<div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '1em', marginBottom: '1em' }}>
 							<p>Password: *******</p>
-							<a style={{ color: 'var(--wisdom)' }} onClick={() => displayEditBlock('password')}>
+							<a style={{ color: 'var(--primary)' }} onClick={() => displayEditBlock('password')}>
 								{displayPassword === 'none' ? 'Edit' : 'Hide'}
 							</a>
 						</div>
@@ -209,7 +210,7 @@ const ProfileModal = (props) => {
 								helperText={passwordHelperText}
 								password={confirmPassword}
 							/>
-							<Button variant="contained" color="primary" onClick={checkPasswords}>
+							<Button className="primaryButton" variant="contained" color="primary" onClick={checkPasswords}>
 								Submit
 							</Button>
 						</form>

--- a/src/components/ProfileModal/index.js
+++ b/src/components/ProfileModal/index.js
@@ -142,7 +142,12 @@ const ProfileModal = (props) => {
 
 	return (
 		<div>
-			<IconButton variant="contained" color="primary" onClick={handleOpen}>
+			<IconButton
+				className="primaryOutlinedButton"
+				variant="contained"
+				color="primary"
+				onClick={handleOpen}
+			>
 				<ManageAccountsIcon />
 			</IconButton>
 			<Modal

--- a/src/components/ProfileModal/index.js
+++ b/src/components/ProfileModal/index.js
@@ -166,7 +166,7 @@ const ProfileModal = (props) => {
 					<div id="profileModal">
 						<h2 className="title" style={{ textDecoration: 'none' }}>EDIT ACCOUNT</h2>
 						<div style={{ display: 'flex', justifyContent: 'space-between' }}>
-							<p>Username: {user.username}</p>
+							<h3>Username: {user.username}</h3>
 							<a style={{ color: 'var(--primary)' }} onClick={() => displayEditBlock('username')}>
 								{displayUsername === 'none' ? 'Edit' : 'Hide'}
 							</a>
@@ -186,7 +186,7 @@ const ProfileModal = (props) => {
 							</Button>
 						</form>
 						<div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '1em', marginBottom: '1em' }}>
-							<p>Password: *******</p>
+							<h3>Password: *******</h3>
 							<a style={{ color: 'var(--primary)' }} onClick={() => displayEditBlock('password')}>
 								{displayPassword === 'none' ? 'Edit' : 'Hide'}
 							</a>

--- a/src/components/Wrapper/style.css
+++ b/src/components/Wrapper/style.css
@@ -1,4 +1,4 @@
-.wrapper, #inventoryModal {
+.wrapper, #inventoryModal, #creditsModal {
     width: 50vw;
     background-color: var(--foreground);
     padding: 20px;

--- a/src/global.css
+++ b/src/global.css
@@ -6,7 +6,8 @@
   --defense: darkgreen;
   --wisdom: darkblue;
   --luck: goldenrod;
-  --primary: darkgoldenrod;
+  --primary: rgb(43, 89, 129);
+  --secondary: darkred;
 }
 
 body {
@@ -98,8 +99,14 @@ a {
 	background-color: var(--primary) !important;
 }
 
+/* focused input boxes */
+.Mui-focused fieldset, .primaryOutlinedButton {
+	color: var(--primary) !important;
+	border-color: var(--primary) !important;
+}
+
 .secondaryButton {
-	background-color: var(--strength) !important;
+	background-color: var(--secondary) !important;
 }
 
 @keyframes fadeIn {

--- a/src/global.css
+++ b/src/global.css
@@ -7,7 +7,9 @@
   --wisdom: darkblue;
   --luck: goldenrod;
   --primary: rgb(43, 89, 129);
+  --primaryDisabled: rgba(43, 89, 129, 0.5);
   --secondary: darkred;
+  --secondaryDisabled: rgba(139, 0, 0, 0.5);
 }
 
 body {
@@ -99,14 +101,27 @@ a {
 	background-color: var(--primary) !important;
 }
 
-/* focused input boxes */
-.Mui-focused fieldset, .primaryOutlinedButton {
-	color: var(--primary) !important;
-	border-color: var(--primary) !important;
+.primaryButton.Mui-disabled {
+	background-color: var(--primaryDisabled) !important;
 }
 
 .secondaryButton {
 	background-color: var(--secondary) !important;
+}
+
+.secondaryButton.Mui-disabled {
+	background-color: var(--secondaryDisabled) !important;
+}
+
+/* focused input boxes */
+.Mui-focused, .primaryOutlinedButton {
+	color: var(--primary) !important;
+	border-color: var(--primary) !important;
+	background-color: var(--foreground);
+}
+
+.Mui-focused {
+	color: var(--background) !important;
 }
 
 @keyframes fadeIn {

--- a/src/global.css
+++ b/src/global.css
@@ -7,9 +7,8 @@
   --wisdom: darkblue;
   --luck: goldenrod;
   --primary: rgb(43, 89, 129);
-  --primaryDisabled: rgba(43, 89, 129, 0.5);
   --secondary: darkred;
-  --secondaryDisabled: rgba(139, 0, 0, 0.5);
+  --choice: darkgoldenrod;
 }
 
 body {
@@ -102,7 +101,7 @@ a {
 }
 
 .primaryButton.Mui-disabled {
-	background-color: var(--primaryDisabled) !important;
+	opacity: 0.5;
 }
 
 .secondaryButton {
@@ -110,7 +109,19 @@ a {
 }
 
 .secondaryButton.Mui-disabled {
-	background-color: var(--secondaryDisabled) !important;
+	opacity: 0.5;
+}
+
+.choiceButton {
+	background-color: var(--choice) !important;
+	color: black !important;
+	font-weight: bold !important;
+}
+
+.choiceButton.Mui-disabled {
+	color: black !important;
+	font-weight: bold !important;
+	opacity: 0.5;
 }
 
 /* focused input boxes */
@@ -155,6 +166,11 @@ a {
 
 .Typewriter, #dialog, #inventoryPopup {
   white-space: pre-line;
+}
+
+#dialog {
+	background-color: var(--foreground);
+	padding: 2em;
 }
 
 /* Scrollbar */

--- a/src/global.css
+++ b/src/global.css
@@ -174,9 +174,14 @@ a {
 	padding: 2em;
 }
 
+#creditsModal {
+	background-color: var(--foreground);
+}
+
+/* Alert */
 .MuiCollapse-root {
 	position: absolute;
-	top: 50%;
+	top: 25%;
 	left: -30%;
 }
 

--- a/src/global.css
+++ b/src/global.css
@@ -102,6 +102,7 @@ a {
 
 .primaryButton.Mui-disabled {
 	opacity: 0.5;
+	color: white !important;
 }
 
 .secondaryButton {
@@ -171,6 +172,12 @@ a {
 #dialog {
 	background-color: var(--foreground);
 	padding: 2em;
+}
+
+.MuiCollapse-root {
+	position: absolute;
+	top: 50%;
+	left: -30%;
 }
 
 /* Scrollbar */

--- a/src/global.css
+++ b/src/global.css
@@ -6,6 +6,7 @@
   --defense: darkgreen;
   --wisdom: darkblue;
   --luck: goldenrod;
+  --primary: darkgoldenrod;
 }
 
 body {
@@ -91,6 +92,14 @@ a {
 
 .luck {
   color: var(--luck);
+}
+
+.primaryButton {
+	background-color: var(--primary) !important;
+}
+
+.secondaryButton {
+	background-color: var(--strength) !important;
 }
 
 @keyframes fadeIn {

--- a/src/pages/CreateAccount/index.js
+++ b/src/pages/CreateAccount/index.js
@@ -144,6 +144,7 @@ const CreateAccount = () => {
 				/>
 
 				<Button
+					className="primaryButton"
 					variant="contained"
 					color="primary"
 					id="submit"

--- a/src/pages/CreateCharacter/index.js
+++ b/src/pages/CreateCharacter/index.js
@@ -144,7 +144,7 @@ const BoundCreateCharacter = (props) => {
 			</div>
 
 			<form id="formWrapper" onSubmit={handleSubmit}>
-				<FormControl>
+				<FormControl style={{ margin: '0 0 1em 0' }}>
 					<TextField
 						className="formInput"
 						label="Name"
@@ -154,7 +154,7 @@ const BoundCreateCharacter = (props) => {
 						helperText={nameHelperText}
 					/>
 				</FormControl>
-				<FormControl>
+				<FormControl style={{ margin: '0 0 1em 0' }}>
 					<InputLabel id="raceLabel">Race</InputLabel>
 					<Select
 						labelId="raceLabel"
@@ -195,6 +195,7 @@ const BoundCreateCharacter = (props) => {
 					</div>
 				</div>
 				<Button
+					className="primaryButton"
 					variant="contained"
 					color="primary"
 					type="submit"

--- a/src/pages/CreateCharacter/index.js
+++ b/src/pages/CreateCharacter/index.js
@@ -133,7 +133,12 @@ const BoundCreateCharacter = (props) => {
 	return (
 		<Wrapper page="createCharacter">
 			<div className="topRow">
-				<Button variant="outlined" id="logout" onClick={logout}>LOG OUT</Button>
+				<Button
+					variant="outlined"
+					id="logout"
+					onClick={logout}
+					className="primaryOutlinedButton"
+				>LOG OUT</Button>
 				<div className="title">CREATE A CHARACTER</div>
 				<a id="back" onClick={() => history('/select')}>&#x2190; BACK</a>
 			</div>

--- a/src/pages/Login/index.js
+++ b/src/pages/Login/index.js
@@ -88,8 +88,8 @@ const BoundLogin = (props) => {
 					/>
 					<Button
 						variant="contained"
-						color="primary"
 						type="submit"
+						className="primaryButton"
 					>
                         Login
 					</Button>

--- a/src/pages/MainStory/index.js
+++ b/src/pages/MainStory/index.js
@@ -320,7 +320,7 @@ const BoundMainStory = (props) => {
 		for (let item of options) {
 			if (levels.visited.includes(item.target)) {
 				let disabledElement = document.getElementById(stringToCamel(item.label));
-				disabledElement.setAttribute('style', 'pointer-events: none; color: rgba(0, 0, 0, 0.26); box-shadow: none; background-color: rgba(0, 0, 0, 0.12);');
+				disabledElement.classList.add('Mui-disabled');
 			}
 		}
 	};

--- a/src/pages/MainStory/index.js
+++ b/src/pages/MainStory/index.js
@@ -638,7 +638,14 @@ const BoundMainStory = (props) => {
 					userHealthWidth={(100 * (currentUserHealth === 1 ? stats.health : currentUserHealth)) / maxHealth}
 				/>
 				<div>
-					<Button type="button" id="save" variant="contained" disabled={buttonDisabled} onClick={saveGame}>Save Game</Button>
+					<Button
+						className="primaryButton"
+						type="button"
+						id="save"
+						variant="contained"
+						disabled={buttonDisabled}
+						onClick={saveGame}
+					>Save Game</Button>
 				</div>
 			</footer>
 			<DefaultPopup customClass="saveSuccess" display={saveGameDisplay} setDisplay={setSaveGameDisplay} message={'Game saved!'} destination="" snackbarColor="success" />

--- a/src/pages/MainStory/index.js
+++ b/src/pages/MainStory/index.js
@@ -570,7 +570,13 @@ const BoundMainStory = (props) => {
 	return (
 		<Wrapper page="main">
 			<div className="topRow">
-				<Button variant="outlined" id="logout" onClick={logout} disabled={buttonDisabled}>LOG OUT</Button>
+				<Button
+					className="primaryOutlinedButton"
+					variant="outlined"
+					id="logout"
+					onClick={logout}
+					disabled={buttonDisabled}
+				>LOG OUT</Button>
 				<img src={smallLogo} alt="a small logo" id="smallLogo" />
 				<a id="back" onClick={() => history('/select')}>QUIT TO<br />MAIN MENU</a>
 			</div>

--- a/src/pages/MainStory/style.css
+++ b/src/pages/MainStory/style.css
@@ -1,5 +1,6 @@
 #speedButton {
     left: 24.5%;
+	color: var(--primary)
 }
 
 .MuiMenu-paper {

--- a/src/pages/SelectCharacter/index.js
+++ b/src/pages/SelectCharacter/index.js
@@ -73,7 +73,12 @@ const BoundSelectCharacter = (props) => {
 	return (
 		<Wrapper page="selectCharacter">
 			<div className="topRow" style={{ marginRight: '0 !important' }}>
-				<Button variant="outlined" id="logout" onClick={logout}>LOG OUT</Button>
+				<Button
+					className="primaryOutlinedButton"
+					variant="outlined"
+					id="logout"
+					onClick={logout}
+				>LOG OUT</Button>
 				<div className="title">SELECT A CHARACTER</div>
 				<ProfileModal user={user} authenticateUser={authenticateUser} resetStore={resetStore} />
 			</div>
@@ -86,7 +91,7 @@ const BoundSelectCharacter = (props) => {
 
 			<div style={{ display: lessThanFour }} id="creatorWrapper" className="characterWrapper">
 				<div id="createNew">Create a new character</div>
-				<IconButton variant="contained" color="primary" onClick={() => history('/create')}>
+				<IconButton variant="contained" className="primaryButton" onClick={() => history('/create')}>
 					<AddIcon />
 				</IconButton>
 			</div>


### PR DESCRIPTION
After upgrading to the new version of Material UI - loads of my styling had broken. This PR goes through and fixes all these areas where colors had changed - especially buttons and inputs - and also changes the `defaultPopup` and `inventoryPopup` components which were using the Snackbox feature from Mui, as this has been deprecated. 